### PR TITLE
Configuración para hacer despliegue en GitHub Package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,4 +23,11 @@
 hs_err_pid*
 replay_pid*
 
+
+/target/
+
+.vscode/
+
 .fake
+!**/src/main/**/target/
+!**/src/test/**/target/

--- a/pom.xml
+++ b/pom.xml
@@ -5,12 +5,59 @@
 
     <groupId>io.github.jhoanhurtado</groupId>
     <artifactId>log-bridge</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.0.0</version>
 
+    <distributionManagement>
+        <repository>
+            <id>github</id>
+            <name>GitHub Packages</name>
+            <url>https://maven.pkg.github.com/JhoanHurtado/log-bridge</url>
+        </repository>
+    </distributionManagement>
+    <repositories>
+        <repository>
+            <id>github</id>
+            <url>https://maven.pkg.github.com/JhoanHurtado/log-bridge</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
     <properties>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.release>21</maven.compiler.release>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
     </properties>
+
+    <name>Queue Helper</name>
+    <description>Es una librería que permite gestionar logs de manera eficiente y flexible. Proporciona múltiples implementaciones de loggers que pueden registrar mensajes en diferentes destinos, como archivos locales y Amazon CloudWatch Logs. Además, permite combinar múltiples loggers para registrar mensajes en varios destinos simultáneamente.</description>
+    <url>https://github.com/JhoanHurtado/log-bridge</url>
+
+    <licenses>
+        <license>
+            <name>MIT License</name>
+            <url>https://opensource.org/licenses/MIT</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <developers>
+        <developer>
+            <id>Jhoan Hurtado</id>
+            <name>Jhoan Ezequiel Hurtado Ramos</name>
+            <email>jhoanezequielh@gmail.com</email>
+            <organization>Jhoan Hurtado</organization>
+            <organizationUrl>https://github.com/jhoanhurtado</organizationUrl>
+        </developer>
+    </developers>
+
+    <scm>
+        <connection>scm:git:git://github.com/JhoanHurtado/log-bridge.git</connection>
+        <developerConnection>scm:git:ssh://github.com:JhoanHurtado/log-bridge.git</developerConnection>
+        <url>https://github.com/JhoanHurtado/log-bridge</url>
+    </scm>
 
     <dependencyManagement>
         <dependencies>
@@ -50,4 +97,22 @@
             <version>1.2.6</version>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <version>3.1.0</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>deploy</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>


### PR DESCRIPTION
Se han realizado los siguientes cambios en el archivo pom.xml:

Adición de dependencias:

Se agregó la dependencia javax:javaee-api en la versión 8.0.1. Se agregó la dependencia ch.qos.logback:logback-classic en la versión 1.2.6. Configuración del plugin de despliegue:

Se configuró el plugin maven-deploy-plugin en la versión 3.1.0 para ejecutar la meta deploy.